### PR TITLE
Fix inserted link not being inserted correctly

### DIFF
--- a/Sources/RichEditorView/Resources/editor/rich_editor.js
+++ b/Sources/RichEditorView/Resources/editor/rich_editor.js
@@ -294,7 +294,7 @@ RE.insertLink = function(url, text, title) {
         sel.removeAllRanges();
         sel.addRange(range);
     }
-    RE.callback();
+    RE.callback("input");
 };
 
 RE.prepareInsert = function() {


### PR DESCRIPTION
This fixes the link not updating into the contentHTML property when this was the last action performed. There was a missing "input" as a parameter to the RE.callback function

I just encountered this bug and this also fixes the issue #26 