### PR TITLE
Added click listener to get current applied format.

### DIFF
--- a/Sources/RichEditorView/Resources/editor/rich_editor.js
+++ b/Sources/RichEditorView/Resources/editor/rich_editor.js
@@ -24,6 +24,60 @@ document.addEventListener("selectionchange", function() {
     RE.backuprange();
 });
 
+document.addEventListener('click', function(event) {
+  // This code will be executed whenever a click occurs anywhere inside the document.
+  // You can replace this code with any action you want to perform when a click happens.
+     var items = [];
+
+     if (document.queryCommandState('bold')) {
+         items.push('bold');
+     }
+     if (document.queryCommandState('italic')) {
+         items.push('italic');
+     }
+     if (document.queryCommandState('subscript')) {
+         items.push('subscript');
+     }
+     if (document.queryCommandState('superscript')) {
+         items.push('superscript');
+     }
+     if (document.queryCommandState('strikeThrough')) {
+         items.push('strikeThrough');
+     }
+     if (document.queryCommandState('underline')) {
+         items.push('underline');
+     }
+     if (document.queryCommandState('insertOrderedList')) {
+         items.push('orderedList');
+     }
+     if (document.queryCommandState('insertUnorderedList')) {
+         items.push('unorderedList');
+     }
+     if (document.queryCommandState('justifyCenter')) {
+         items.push('justifyCenter');
+     }
+     if (document.queryCommandState('justifyFull')) {
+         items.push('justifyFull');
+     }
+     if (document.queryCommandState('justifyLeft')) {
+         items.push('justifyLeft');
+     }
+     if (document.queryCommandState('justifyRight')) {
+         items.push('justifyRight');
+     }
+     if (document.queryCommandState('insertHorizontalRule')) {
+         items.push('horizontalRule');
+     }
+     var formatBlock = document.queryCommandValue('formatBlock');
+     if (formatBlock.length > 0) {
+         items.push(formatBlock);
+     }
+
+     const allAppliedFormat = items.toString()
+     RE.callback(allAppliedFormat)
+
+});
+
 //looks specifically for a Range selection and not a Caret selection
 RE.rangeSelectionExists = function() {
     //!! coerces a null to bool

--- a/Sources/RichEditorView/Resources/editor/style.css
+++ b/Sources/RichEditorView/Resources/editor/style.css
@@ -65,7 +65,7 @@ div {
     height: 100%;
     overflow: auto;
     display: block;
-    font-size: 32pt;
+    font-size: 12pt;
 }
 
 input[type=checkbox] {

--- a/Sources/RichEditorView/Resources/editor/style.css
+++ b/Sources/RichEditorView/Resources/editor/style.css
@@ -65,7 +65,7 @@ div {
     height: 100%;
     overflow: auto;
     display: block;
-    font-size: 12pt;
+    font-size: 32pt;
 }
 
 input[type=checkbox] {

--- a/Sources/RichEditorView/RichEditorView.swift
+++ b/Sources/RichEditorView/RichEditorView.swift
@@ -423,7 +423,7 @@ public class RichEditorWebView: WKWebView {
         webView.evaluateJavaScript(js) {(result, error) in
             if let error = error {
                 print("WKWebViewJavascriptBridge Error: \(String(describing: error)) - JS: \(js)")
-                handler?("")
+                handler?("WKWebViewJavascriptBridge Error: \(String(describing: error)) - JS: \(js)")
                 return
             }
             

--- a/Sources/RichEditorView/RichEditorView.swift
+++ b/Sources/RichEditorView/RichEditorView.swift
@@ -620,6 +620,11 @@ public class RichEditorWebView: WKWebView {
                 self.delegate?.richEditor?(self, handle: action)
             }
         }
+        else {
+              if let delegate = delegate{
+                  delegate.richEditor?(self, handle:method)
+              }
+        }
     }
     
     // MARK: - Responder Handling


### PR DESCRIPTION
<!-- Thanks for contributing! ❤️ -->

<!--
📝 Write a short description of what you did here. Things like "Added a header
image" are good, while "More code" isn't so good. Don't worry, it doesn't need
to be perfect, this just helps speed review processes along!
-->

Problem: [Issue Link](https://github.com/Andrew-Chen-Wang/RichEditorView/issues/29)

Soluation:   We have added the click listener which will send all applied format for current tag. 

PFA: 

https://github.com/Andrew-Chen-Wang/RichEditorView/assets/8275040/c1e592d6-7c5f-4724-b39f-0c5b848f5c28

This enhancement is particularly beneficial, as it introduces an event that empowers users to effortlessly retrieve an array of applied formats. By capturing content changes through our delegate method and manually invoking the click event, users gain streamlined access to a comprehensive array of string-based formats that have been applied

Example Code: 

```
extension TestViewController: RichEditorDelegate {
   
    func richEditor(_ editor: RichEditorView, handle action: String) {
        
        let commaSeparatedString = action
        let arrayOfStrings = commaSeparatedString.split(separator: ",").map { String($0) }
        
        buttonStateChange(
            isSelected: arrayOfStrings.contains("unorderedList") ? true : false,
            format: .bulletPoint
        )
        
    }
    
   func richEditor(_ editor: RichEditorView, contentDidChange content: String) {
                
       editor.runJS("document.querySelector('body').click();")
        
		if content.count > 40000 {
			editor.html = prevText
		} else {
			prevText = content
		}
             
	}
        
}

```